### PR TITLE
Issue 171

### DIFF
--- a/plugins/com.yakindu.solidity.ui/META-INF/MANIFEST.MF
+++ b/plugins/com.yakindu.solidity.ui/META-INF/MANIFEST.MF
@@ -20,7 +20,8 @@ Require-Bundle: com.yakindu.solidity,
  org.yakindu.base.expressions.ui,
  org.yakindu.base.types,
  org.yakindu.base.xtext.utils.jface,
- org.eclipse.xtext.xbase.lib
+ org.eclipse.xtext.xbase.lib,
+ org.eclipse.emf.workspace
 Import-Package: org.apache.log4j
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: com.yakindu.solidity.ui.contentassist,

--- a/plugins/com.yakindu.solidity.ui/src/com/yakindu/solidity/ui/contentassist/SolidityProposalProvider.xtend
+++ b/plugins/com.yakindu.solidity.ui/src/com/yakindu/solidity/ui/contentassist/SolidityProposalProvider.xtend
@@ -91,7 +91,7 @@ class SolidityProposalProvider extends AbstractSolidityProposalProvider {
 			}
 		})
 		result.forEach [
-			acceptor.accept(createCompletionProposal("\"" + rawLocation.makeRelativeTo(contextFile.rawLocation).toString + "\";", name, null, context))
+			acceptor.accept(createCompletionProposal("\"" + rawLocation.makeRelativeTo(contextFile.rawLocation).toString.replaceFirst("../","") + "\";", name, null, context))
 		]
 	}
 

--- a/plugins/com.yakindu.solidity.ui/src/com/yakindu/solidity/ui/editor/SolidityHyperlinkHelper.java
+++ b/plugins/com.yakindu.solidity.ui/src/com/yakindu/solidity/ui/editor/SolidityHyperlinkHelper.java
@@ -14,15 +14,24 @@
  */
 package com.yakindu.solidity.ui.editor;
 
+import java.util.List;
+
 import javax.inject.Inject;
 
+import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.jface.text.Region;
+import org.eclipse.xtext.nodemodel.INode;
+import org.eclipse.xtext.nodemodel.util.NodeModelUtils;
 import org.eclipse.xtext.resource.XtextResource;
 import org.eclipse.xtext.ui.editor.hyperlinking.HyperlinkHelper;
 import org.eclipse.xtext.ui.editor.hyperlinking.IHyperlinkAcceptor;
+import org.eclipse.xtext.ui.editor.hyperlinking.XtextHyperlink;
 import org.yakindu.base.types.typesystem.AbstractTypeSystem;
 import org.yakindu.base.types.typesystem.ITypeSystem;
+
+import com.yakindu.solidity.solidity.ImportDirective;
+import com.yakindu.solidity.solidity.SolidityPackage;
 
 /**
  * Hyperlinking customizations:
@@ -30,6 +39,7 @@ import org.yakindu.base.types.typesystem.ITypeSystem;
  * <li>Disable hyperlinks for build-in elements
  * 
  * @author Karsten Thoms - Initial contribution and API 
+ * @author Jonathan Thoene
  *
  */
 public class SolidityHyperlinkHelper extends HyperlinkHelper {
@@ -43,5 +53,45 @@ public class SolidityHyperlinkHelper extends HyperlinkHelper {
 			return;
 		}
 		super.createHyperlinksTo(from, region, target, acceptor);
+	}
+	
+	@Override
+	public void createHyperlinksByOffset(XtextResource resource, int offset, IHyperlinkAcceptor acceptor) {
+		createImportedNamespacesHyperlinksByOffset(resource, offset, acceptor);
+		super.createHyperlinksByOffset(resource, offset, acceptor);
+	}
+
+	protected void createImportedNamespacesHyperlinksByOffset(XtextResource resource, int offset,
+			IHyperlinkAcceptor acceptor) {
+		INode node = NodeModelUtils.findLeafNodeAtOffset(resource.getParseResult().getRootNode(), offset);
+		if (node != null) {			
+			List<INode> importNodes = NodeModelUtils.findNodesForFeature(node.getSemanticElement(), SolidityPackage.Literals.IMPORT_DIRECTIVE__IMPORTED_NAMESPACE);
+			if (importNodes != null && !importNodes.isEmpty()) {
+				for (INode importNode : importNodes) {
+					ImportDirective importElement = (ImportDirective) importNode.getSemanticElement();
+					URI targetURI = getFileURIOfImport(importElement);
+					XtextHyperlink result = getHyperlinkProvider().get();
+					result.setURI(targetURI);
+					Region region = new Region(importNode.getOffset(), importNode.getLength());
+					result.setHyperlinkRegion(region);
+					result.setHyperlinkText(targetURI.toString());
+					acceptor.accept(result);
+				}
+			}
+		}
+	}
+	
+	protected URI getFileURIOfImport (ImportDirective importElement) {
+		URI fileURI = importElement.eResource().getURI().trimSegments(1);
+		String importURI = importElement.getImportedNamespace();
+		while (importURI.startsWith("../")) {
+			fileURI = fileURI.trimSegments(1);
+			importURI = importURI.replaceFirst("../", "");
+		}
+		String[] segments = importURI.split("/");
+		for (String segment : segments) {
+			fileURI = fileURI.appendSegment(segment);
+		}
+		return fileURI;
 	}
 }

--- a/plugins/com.yakindu.solidity.ui/src/com/yakindu/solidity/ui/outline/SolidityOutlineTreeProvider.xtend
+++ b/plugins/com.yakindu.solidity.ui/src/com/yakindu/solidity/ui/outline/SolidityOutlineTreeProvider.xtend
@@ -15,6 +15,7 @@
 package com.yakindu.solidity.ui.outline
 
 import com.yakindu.solidity.solidity.ConstructorDefinition
+import com.yakindu.solidity.solidity.ImportDirective
 import com.yakindu.solidity.solidity.SolidityModel
 import com.yakindu.solidity.solidity.SourceUnit
 import org.eclipse.emf.ecore.EObject
@@ -50,6 +51,7 @@ class SolidityOutlineTreeProvider extends DefaultOutlineTreeProvider {
 	override protected Object _text(Object element) {
 		switch element {
 			ConstructorDefinition: return "constructor"
+			ImportDirective : return element.importedNamespace.shortenImportedNamespace
 			default: return super._text(element)
 		}
 	}
@@ -59,5 +61,10 @@ class SolidityOutlineTreeProvider extends DefaultOutlineTreeProvider {
 			Declaration: true
 			default: return super._isLeaf(element)
 		}
+	}
+	
+	def protected String shortenImportedNamespace (String namespace) {
+		var segments = namespace.split("/");
+		return segments.get(segments.length-1).replace(".sol","")
 	}
 }


### PR DESCRIPTION
This Pullrequest fixes #171 

The code completion for import directives now provides a list of all solidity files in the same eclipse project. Also the hyperlinking for the imports was implement, if I know press CTRL + Leftclick on the import i will be directed to the imported file. Lastly the outline view was adapted and now only shows the name of the imported solidity file as node label for an import directive node.