### PR TITLE
Adding dependencies to ide project

### DIFF
--- a/plugins/com.yakindu.solidity.ide/META-INF/MANIFEST.MF
+++ b/plugins/com.yakindu.solidity.ide/META-INF/MANIFEST.MF
@@ -10,7 +10,8 @@ Require-Bundle: com.yakindu.solidity,
  org.eclipse.lsp4j;bundle-version="0.4.0",
  org.eclipse.lsp4j.jsonrpc;bundle-version="0.4.0",
  org.antlr.runtime;bundle-version="[3.2.0,3.2.1)",
- com.google.gson
+ com.google.gson,
+ org.eclipse.emf.ecore.change
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: com.yakindu.solidity.ide.contentassist.antlr,
  com.yakindu.solidity.ide.contentassist.antlr.internal


### PR DESCRIPTION
With the "org.eclipse.emf.ecore.change" dependency the renaming feature
in the VSCode Integration now also works.