### PR TITLE
pinned dependent SCT version

### DIFF
--- a/features/com.yakindu.solidity.feature/feature.xml
+++ b/features/com.yakindu.solidity.feature/feature.xml
@@ -22,6 +22,10 @@
       <discovery label="YAKINDU SCT Repository" url="http://updates.yakindu.com/statecharts/releases/"/>
    </url>
 
+   <requires>
+      <import feature="org.yakindu.base" version="3.4.0.201808160934" match="perfect"/>
+   </requires>
+
    <plugin
          id="com.yakindu.solidity"
          download-size="0"


### PR DESCRIPTION
Pinned the compatible SCT version to 3.4.0. If we install it via update site, SCT 3.4.3 is used instead that has an incompatible change in the meta model. 
fixes #224 
fixes #197