### PR TITLE
Function Signature formatting alligned to styleguide

### DIFF
--- a/plugins/com.yakindu.solidity.ui/src/com/yakindu/solidity/ui/highlighting/SoliditySemanticHighlighter.java
+++ b/plugins/com.yakindu.solidity.ui/src/com/yakindu/solidity/ui/highlighting/SoliditySemanticHighlighter.java
@@ -114,7 +114,7 @@ public class SoliditySemanticHighlighter
 
 	private void provideHighLightForNamedElement(NamedElement namedElement, INode nextNode, String textStyle,
 			IHighlightedPositionAcceptor acceptor) {
-		acceptor.addPosition(nextNode.getOffset(), nextNode.getLength() + 1, textStyle);
+		acceptor.addPosition(nextNode.getOffset(), nextNode.getLength(), textStyle);
 		List<ElementReferenceExpression> references = EcoreUtil2.getAllContentsOfType(namedElement.eContainer(),
 				ElementReferenceExpression.class);
 		for (ElementReferenceExpression elementReferenceExpression : references) {


### PR DESCRIPTION
Function signatures still not getting formatted exactly according to the
style guide but much more than before. In detail: If the function
signature is longer than 80 characters, the parameters of the function
are now listed line by line instead of multiple parameters in one line.
If the function signature is shorter than 80 characters the signature
will be formatted in one line.
Also the SemanticHighlighter had a bug which was fixed.