### PR TITLE
fixed #297

### DIFF
--- a/plugins/com.yakindu.solidity/src/com/yakindu/solidity/formatting2/SolidityFormatter.xtend
+++ b/plugins/com.yakindu.solidity/src/com/yakindu/solidity/formatting2/SolidityFormatter.xtend
@@ -39,7 +39,6 @@ import com.yakindu.solidity.solidity.TupleExpression
 import com.yakindu.solidity.solidity.VariableDefinition
 import com.yakindu.solidity.solidity.WhileStatement
 import com.yakindu.solidity.solidity.InlineAssemblyBlock
-import com.yakindu.solidity.solidity.InlineAssemblyStatement
 import com.yakindu.solidity.solidity.FunctionalAssemblyExpression
 import org.eclipse.xtext.formatting2.AbstractFormatter2
 import org.eclipse.xtext.formatting2.IFormattableDocument

--- a/plugins/com.yakindu.solidity/src/com/yakindu/solidity/formatting2/SolidityFormatter.xtend
+++ b/plugins/com.yakindu.solidity/src/com/yakindu/solidity/formatting2/SolidityFormatter.xtend
@@ -39,6 +39,8 @@ import com.yakindu.solidity.solidity.TupleExpression
 import com.yakindu.solidity.solidity.VariableDefinition
 import com.yakindu.solidity.solidity.WhileStatement
 import com.yakindu.solidity.solidity.InlineAssemblyBlock
+import com.yakindu.solidity.solidity.InlineAssemblyStatement
+import com.yakindu.solidity.solidity.FunctionalAssemblyExpression
 import org.eclipse.xtext.formatting2.AbstractFormatter2
 import org.eclipse.xtext.formatting2.IFormattableDocument
 import org.eclipse.xtext.formatting2.IHiddenRegionFormatter
@@ -465,6 +467,17 @@ class SolidityFormatter extends AbstractFormatter2 {
 			format;
 			prepend[noSpace];
 			append[newLines(1, 1, 2); priority = IHiddenRegionFormatter.HIGH_PRIORITY];
+		]
+	}
+
+	 /* com.yakindu.solidity.solidity.impl.AssemblyLocalBindingImpl@6a1b51a7 (label: size)
+com.yakindu.solidity.solidity.impl.AssemblyAssignmentImpl@5ea206bc (leftOperand: o_code, rightOpernd: null)
+com.yakindu.solidity.solidity.impl.FunctionalAssemblyExpressionImpl@7b6bcbee (label: extcodecopy)
+	 */
+	def dispatch void format(FunctionalAssemblyExpression it, extension IFormattableDocument document) {
+		parameters.forEach[
+			prepend[oneSpace]
+			append[noSpace]
 		]
 	}
 

--- a/plugins/com.yakindu.solidity/src/com/yakindu/solidity/formatting2/SolidityFormatter.xtend
+++ b/plugins/com.yakindu.solidity/src/com/yakindu/solidity/formatting2/SolidityFormatter.xtend
@@ -472,10 +472,9 @@ class SolidityFormatter extends AbstractFormatter2 {
 
 	def dispatch void format(FunctionalAssemblyExpression it, extension IFormattableDocument document) {
 		val int assemblyExpressionLength = getLengthOfAssemblyExpression
-
-		if (assemblyExpressionLength >= 80) {//setOnAutoWrap
+		if (assemblyExpressionLength >= 80) {
 			regionFor.keywordPairs('(', ')').forEach [
-				key.prepend[oneSpace]
+				key.prepend[noSpace]
 				key.append[newLine]
 				value.prepend[newLine]
 			]
@@ -489,8 +488,8 @@ class SolidityFormatter extends AbstractFormatter2 {
 				prepend[oneSpace]
 				append[noSpace]
 			]
+			regionFor.keyword(",").append[oneSpace].prepend[noSpace]
 		}
-
 	}
 
 	protected def void newLines(IHiddenRegionFormatter it) {
@@ -548,14 +547,15 @@ class SolidityFormatter extends AbstractFormatter2 {
 	}
 
 	protected def int getLengthOfAssemblyExpression(FunctionalAssemblyExpression it) {
-		val int labelLength = label.toString.length
-		val int parametersLength = 0
+		var int labelLength = label.length
 		
+		var int parametersLength = 0// + 2(for open/close brackets) - 2(the last parameter is not followed by comma and space)
 		for (parameter : parameters) {
-			//parametersLength += parameter.regionForEObject.length
-			//parametersLength += 2;
+			parametersLength += parameter.regionForEObject.length
+			parametersLength += 2//for each comma+space after parameter
 		}
-
-		return labelLength + parametersLength;
+		
+		var sum = labelLength + parametersLength;
+		return sum;
 	}
 }

--- a/plugins/com.yakindu.solidity/src/com/yakindu/solidity/formatting2/SolidityFormatter.xtend
+++ b/plugins/com.yakindu.solidity/src/com/yakindu/solidity/formatting2/SolidityFormatter.xtend
@@ -471,10 +471,26 @@ class SolidityFormatter extends AbstractFormatter2 {
 	}
 
 	def dispatch void format(FunctionalAssemblyExpression it, extension IFormattableDocument document) {
-		parameters.forEach[
-			prepend[oneSpace]
-			append[noSpace]
-		]
+		val int assemblyExpressionLength = getLengthOfAssemblyExpression
+
+		if (assemblyExpressionLength >= 80) {//setOnAutoWrap
+			regionFor.keywordPairs('(', ')').forEach [
+				key.prepend[oneSpace]
+				key.append[newLine]
+				value.prepend[newLine]
+			]
+			parameters.forEach [
+				prepend[newLine]
+				indent(document)
+				append[noSpace]
+			]
+		} else {
+			parameters.forEach [
+				prepend[oneSpace]
+				append[noSpace]
+			]
+		}
+
 	}
 
 	protected def void newLines(IHiddenRegionFormatter it) {
@@ -529,5 +545,17 @@ class SolidityFormatter extends AbstractFormatter2 {
 			returnParametersLength += returnParam.regionForEObject.length
 		}
 		return (functionKeywordLength + nameLength + parametersLength + modifiersLength + returnParametersLength)
+	}
+
+	protected def int getLengthOfAssemblyExpression(FunctionalAssemblyExpression it) {
+		val int labelLength = label.toString.length
+		val int parametersLength = 0
+		
+		for (parameter : parameters) {
+			//parametersLength += parameter.regionForEObject.length
+			//parametersLength += 2;
+		}
+
+		return labelLength + parametersLength;
 	}
 }

--- a/plugins/com.yakindu.solidity/src/com/yakindu/solidity/formatting2/SolidityFormatter.xtend
+++ b/plugins/com.yakindu.solidity/src/com/yakindu/solidity/formatting2/SolidityFormatter.xtend
@@ -470,10 +470,6 @@ class SolidityFormatter extends AbstractFormatter2 {
 		]
 	}
 
-	 /* com.yakindu.solidity.solidity.impl.AssemblyLocalBindingImpl@6a1b51a7 (label: size)
-com.yakindu.solidity.solidity.impl.AssemblyAssignmentImpl@5ea206bc (leftOperand: o_code, rightOpernd: null)
-com.yakindu.solidity.solidity.impl.FunctionalAssemblyExpressionImpl@7b6bcbee (label: extcodecopy)
-	 */
 	def dispatch void format(FunctionalAssemblyExpression it, extension IFormattableDocument document) {
 		parameters.forEach[
 			prepend[oneSpace]


### PR DESCRIPTION
added `def dispatch void format(FunctionalAssemblyExpression it, extension IFormattableDocument document)`
and `protected def int getLengthOfAssemblyExpression(FunctionalAssemblyExpression it)`

which allow formatting of assembly expressions with less and more than 80 characters