### PR TITLE
[#318] yarn install without --production flag

### DIFF
--- a/extensions/Dockerfile
+++ b/extensions/Dockerfile
@@ -22,7 +22,7 @@ WORKDIR /home/node
 COPY --chown=node:node theia ./theia
 
 WORKDIR /home/node/theia
-RUN yarn install --production
+RUN yarn install
 
 WORKDIR /home/node/
 


### PR DESCRIPTION
If the --production flag is set, the devDepencies of npm will not be installed. But `@theia/cli` has to be a devDependency and is needed for the production.

Should fix #318 